### PR TITLE
Amartz/cognitive services

### DIFF
--- a/Samples/All/BumbleRumble/Common/GameScreen.cpp
+++ b/Samples/All/BumbleRumble/Common/GameScreen.cpp
@@ -11,6 +11,7 @@
 #include "Managers.h"
 #include "GameScreen.h"
 #include "STTOverlayScreen.h"
+#include "OptionsPopUpScreen.h"
 
 #if !defined(_XBOX_ONE)
 #include "InputBoxScreen.h"
@@ -105,20 +106,31 @@ void GameScreen::HandleInput()
     auto inputManager = Managers::Get<InputManager>();
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
-    if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
-    {
-        concurrency::create_task(
-            Windows::Xbox::UI::SystemUI::ShowVirtualKeyboardAsync(
-                L"This is a text message",
-                L"Send Text Message",
-                L"Enter text to send:",
-                Windows::Xbox::UI::VirtualKeyboardInputScope::Default
-            )
-        ).then([](Platform::String^ text)
-        {
-            Managers::Get<NetworkManager>()->SendTextAsVoice(BumbleRumble::WStrToStr(text->Data()));
-        });
-    }
+	if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
+	{
+		Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
+	}
+	else if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
+	{
+		if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
+		{
+			concurrency::create_task(
+				Windows::Xbox::UI::SystemUI::ShowVirtualKeyboardAsync(
+					L"This is a text message",
+					L"Send Text Message",
+					L"Enter text to send:",
+					Windows::Xbox::UI::VirtualKeyboardInputScope::Default
+				)
+			).then([](Platform::String^ text)
+			{
+				Managers::Get<NetworkManager>()->SendTextAsVoice(BumbleRumble::WStrToStr(text->Data()));
+			});
+		}
+		else
+		{
+			Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
+		}
+	}
 
     if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::DPadUp))
     {
@@ -149,11 +161,22 @@ void GameScreen::HandleInput()
         }
     }
 
-    if (inputManager->IsNewKeyPress(DirectX::Keyboard::Tab))
-    {
-        Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<InputBoxScreen>());
-    }
-
+	if (inputManager->IsNewKeyPress(DirectX::Keyboard::Escape))
+	{
+		Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
+	}
+	else if (inputManager->IsNewKeyPress(DirectX::Keyboard::Tab))
+	{
+		if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
+		{
+			Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<InputBoxScreen>());
+		}
+		else
+		{
+			Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
+		}
+	}
+	
     if (inputManager->IsNewKeyPress(DirectX::Keyboard::D4) && inputManager->CurrentKeyboardState().IsKeyDown(DirectX::Keyboard::LeftAlt))
     {
         Managers::Get<NetworkManager>()->SendTextMessage("Great job!");

--- a/Samples/All/BumbleRumble/Common/GameScreen.cpp
+++ b/Samples/All/BumbleRumble/Common/GameScreen.cpp
@@ -106,31 +106,31 @@ void GameScreen::HandleInput()
     auto inputManager = Managers::Get<InputManager>();
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
-	if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
-	{
-		Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
-	}
-	else if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
-	{
-		if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
-		{
-			concurrency::create_task(
-				Windows::Xbox::UI::SystemUI::ShowVirtualKeyboardAsync(
-					L"This is a text message",
-					L"Send Text Message",
-					L"Enter text to send:",
-					Windows::Xbox::UI::VirtualKeyboardInputScope::Default
-				)
-			).then([](Platform::String^ text)
-			{
-				Managers::Get<NetworkManager>()->SendTextAsVoice(BumbleRumble::WStrToStr(text->Data()));
-			});
-		}
-		else
-		{
-			Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
-		}
-	}
+    if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::Menu))
+    {
+        Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
+    }
+    else if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::View))
+    {
+        if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
+        {
+            concurrency::create_task(
+                Windows::Xbox::UI::SystemUI::ShowVirtualKeyboardAsync(
+                    L"This is a text message",
+                    L"Send Text Message",
+                    L"Enter text to send:",
+                    Windows::Xbox::UI::VirtualKeyboardInputScope::Default
+                )
+            ).then([](Platform::String^ text)
+            {
+                Managers::Get<NetworkManager>()->SendTextAsVoice(BumbleRumble::WStrToStr(text->Data()));
+            });
+        }
+        else
+        {
+            Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
+        }
+    }
 
     if (inputManager->IsNewButtonPress(InputManager::GamepadButtons::DPadUp))
     {
@@ -161,22 +161,22 @@ void GameScreen::HandleInput()
         }
     }
 
-	if (inputManager->IsNewKeyPress(DirectX::Keyboard::Escape))
-	{
-		Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
-	}
-	else if (inputManager->IsNewKeyPress(DirectX::Keyboard::Tab))
-	{
-		if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
-		{
-			Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<InputBoxScreen>());
-		}
-		else
-		{
-			Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
-		}
-	}
-	
+    if (inputManager->IsNewKeyPress(DirectX::Keyboard::Escape))
+    {
+        Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<OptionsPopUpScreen>());
+    }
+    else if (inputManager->IsNewKeyPress(DirectX::Keyboard::Tab))
+    {
+        if (Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled())
+        {
+            Managers::Get<ScreenManager>()->AddGameScreen(std::make_shared<InputBoxScreen>());
+        }
+        else
+        {
+            Managers::Get<ScreenManager>()->ShowError("Cognitive Services must be enabled to use Text-To-Speech.");
+        }
+    }
+
     if (inputManager->IsNewKeyPress(DirectX::Keyboard::D4) && inputManager->CurrentKeyboardState().IsKeyDown(DirectX::Keyboard::LeftAlt))
     {
         Managers::Get<NetworkManager>()->SendTextMessage("Great job!");

--- a/Samples/All/BumbleRumble/Common/NetworkManager.cpp
+++ b/Samples/All/BumbleRumble/Common/NetworkManager.cpp
@@ -80,6 +80,7 @@ NetworkManager::NetworkManager() :
     m_localUser(nullptr),
     m_localChatControl(nullptr),
     m_partyInitialized(false),
+	m_enableCognitiveServices(false),
     m_languageCode("en-US"),
     m_languageName("English (United States)")
 {
@@ -123,11 +124,10 @@ void NetworkManager::Initialize()
 
 void NetworkManager::CreateLocalUser()
 {
-    auto& partyManager = PartyManager::GetSingleton();
-    PartyError err;
-
     if (m_localUser == nullptr)
     {
+		auto& partyManager = PartyManager::GetSingleton();
+		PartyError err;
         PartyString entityId = Managers::Get<PlayFabManager>()->EntityId().c_str();
         PartyString entityToken = Managers::Get<PlayFabManager>()->EntityToken().c_str();
 
@@ -144,102 +144,72 @@ void NetworkManager::CreateLocalUser()
             return;
         }
     }
+}
 
-    if (m_localChatControl == nullptr)
-    {
-        PartyLocalDevice* localDevice = nullptr;
+void NetworkManager::CreateLocalChatControl()
+{
+	if (m_localChatControl == nullptr)
+	{
+		auto& partyManager = PartyManager::GetSingleton();
+		PartyError err;
+		PartyLocalDevice* localDevice = nullptr;
 
-        // Retrieve the local device
-        err = partyManager.GetLocalDevice(&localDevice);
+		// Retrieve the local device
+		err = partyManager.GetLocalDevice(&localDevice);
 
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("GetLocalDevice failed: %hs\n", GetErrorMessage(err));
-            return;
-        }
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("GetLocalDevice failed: %hs\n", GetErrorMessage(err));
+			return;
+		}
 
-        // Create a chat control for the local user on the local device
-        err = localDevice->CreateChatControl(
-            m_localUser,                                // Local user object
-            m_languageCode.c_str(),                     // Language id
-            nullptr,                                    // Async identifier
-            &m_localChatControl                         // OUT local chat control
-            );
+		// Create a chat control for the local user on the local device
+		err = localDevice->CreateChatControl(
+			m_localUser,                                // Local user object
+			m_languageCode.c_str(),                     // Language id
+			nullptr,                                    // Async identifier
+			&m_localChatControl                         // OUT local chat control
+		);
 
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("CreateChatControl failed: %hs\n", GetErrorMessage(err));
-            return;
-        }
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("CreateChatControl failed: %hs\n", GetErrorMessage(err));
+			return;
+		}
 
-        // Use automatic settings for the audio input device
-        err = m_localChatControl->SetAudioInput(
-            PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
-            nullptr,                                        // Device id
-            nullptr                                         // Async identifier
-            );
+		// Use automatic settings for the audio input device
+		err = m_localChatControl->SetAudioInput(
+			PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
+			nullptr,                                        // Device id
+			nullptr                                         // Async identifier
+		);
 
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("SetAudioInput failed: %hs\n", GetErrorMessage(err));
-            return;
-        }
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("SetAudioInput failed: %hs\n", GetErrorMessage(err));
+			return;
+		}
 
-        // Use automatic settings for the audio output device
-        err = m_localChatControl->SetAudioOutput(
-            PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
-            nullptr,                                        // Device id
-            nullptr                                         // Async identifier
-            );
+		// Use automatic settings for the audio output device
+		err = m_localChatControl->SetAudioOutput(
+			PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
+			nullptr,                                        // Device id
+			nullptr                                         // Async identifier
+		);
 
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("SetAudioOutput failed: %hs\n", GetErrorMessage(err));
-        }
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("SetAudioOutput failed: %hs\n", GetErrorMessage(err));
+		}
 
-        // For purposes of the sample, force this on always
-        DEBUGLOG("Enabling Speech-To-Text.\n");
+		// Get the available list of text to speech profiles
+		err = m_localChatControl->PopulateAvailableTextToSpeechProfiles(nullptr);
 
-        // Set transcription options for transcribing other users regardless of language, and ourselves.
-        PartyVoiceChatTranscriptionOptions transcriptionOptions =
-            PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithMatchingLanguages |
-            PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithNonMatchingLanguages |
-            PartyVoiceChatTranscriptionOptions::TranslateToLocalLanguage |
-            PartyVoiceChatTranscriptionOptions::TranscribeSelf;
-
-        // Set the transcription options on our chat control.
-        err = m_localChatControl->SetTranscriptionOptions(
-            transcriptionOptions,                       // Transcription options
-            nullptr                                     // Async identifier
-            );
-
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("SetTranscriptionOptions failed: %s\n", GetErrorMessage(err));
-        }
-
-        // For purposes of the sample, force this on always
-        DEBUGLOG("Enabling Text-To-Speech.\n");
-
-        // Get the available list of text to speech profiles
-        err = m_localChatControl->PopulateAvailableTextToSpeechProfiles(nullptr);
-
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("Populating available TextToSpeechProfiles failed: %s \n", GetErrorMessage(err));
-        }
-
-        // Enable translation to local language in chat controls.
-        err = m_localChatControl->SetTextChatOptions(
-            PartyTextChatOptions::TranslateToLocalLanguage,
-            nullptr
-            );
-
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("SetTextChatOptions failed: %s\n", GetErrorMessage(err));
-        }
-    }
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("Populating available TextToSpeechProfiles failed: %s \n", GetErrorMessage(err));
+		}
+	}
 }
 
 void NetworkManager::Shutdown()
@@ -362,6 +332,8 @@ bool NetworkManager::InternalConnectToNetwork(const char* inviteId, Party::Party
         return false;
     }
 
+	CreateLocalChatControl();
+
     // Connect the local user chat control to the network so we can use VOIP
     err = m_network->ConnectChatControl(
         m_localChatControl,                         // Local chat control
@@ -374,7 +346,7 @@ bool NetworkManager::InternalConnectToNetwork(const char* inviteId, Party::Party
         return false;
     }
 
-    // Establish a network endoint for game message traffic
+    // Establish a network endpoint for game message traffic
     err = m_network->CreateEndpoint(
         m_localUser,                                // Local user
         0,                                          // Property Count
@@ -485,21 +457,24 @@ void NetworkManager::SendTextMessage(std::string text)
 
 void NetworkManager::SendTextAsVoice(std::string text)
 {
-    if (m_localChatControl != nullptr)
-    {
-        DEBUGLOG("Requesting transcription of: %hs\n", text.c_str());
+	if (m_enableCognitiveServices)
+	{
+		if (m_localChatControl != nullptr)
+		{
+			DEBUGLOG("Requesting transcription of: %hs\n", text.c_str());
 
-        PartyError err = m_localChatControl->SynthesizeTextToSpeech(
-            PartySynthesizeTextToSpeechType::VoiceChat,
-            text.c_str(),                           // Text to synthesize
-            nullptr                                 // Async identifier
-            );
+			PartyError err = m_localChatControl->SynthesizeTextToSpeech(
+				PartySynthesizeTextToSpeechType::VoiceChat,
+				text.c_str(),                           // Text to synthesize
+				nullptr                                 // Async identifier
+			);
 
-        if (PARTY_FAILED(err))
-        {
-            DEBUGLOG("Failed to SynthesizeTextToSpeech: %hs\n", GetErrorMessage(err));
-        }
-    }
+			if (PARTY_FAILED(err))
+			{
+				DEBUGLOG("Failed to SynthesizeTextToSpeech: %hs\n", GetErrorMessage(err));
+			}
+		}
+	}
 }
 
 void NetworkManager::LeaveNetwork(std::function<void(void)> callback)
@@ -1223,4 +1198,75 @@ PartyChatControl* NetworkManager::GetChatControl(std::string& peer)
         return itr->second;
     }
     return nullptr;
+}
+
+void BumbleRumble::NetworkManager::SetCognitiveServicesEnabled(bool bEnabled)
+{
+	m_enableCognitiveServices = bEnabled;
+
+	// For the purposes of the sample, enable or disable all possible features
+	SetTextChatTranslationOptions(bEnabled);
+	SetVoiceChatTranscriptionOptions(bEnabled, bEnabled, bEnabled, false, bEnabled); 
+}
+
+void BumbleRumble::NetworkManager::SetTextChatTranslationOptions(bool bTranslateToLocalLanguage)
+{
+	DEBUGLOG("SetTextChatTranslationOptions: bTranslateToLocalLanguage = %s", bTranslateToLocalLanguage ? "Enabled" : "Disabled");
+
+	// Enable translation to local language in chat controls.
+	PartyError err = m_localChatControl->SetTextChatOptions(
+		bTranslateToLocalLanguage ? PartyTextChatOptions::TranslateToLocalLanguage : PartyTextChatOptions::None,
+		nullptr
+	);
+
+	if (PARTY_FAILED(err))
+	{
+		DEBUGLOG("SetTextChatOptions failed: %s\n", GetErrorMessage(err));
+	}
+}
+
+void BumbleRumble::NetworkManager::SetVoiceChatTranscriptionOptions(bool bTranscribeSelf, bool bTranscribeOtherChatControlsWithMatchingLanguages, bool bTranscribeOtherChatControlsWithNonMatchingLanguages, bool bDisableHypothesisPhrases, bool bTranslateToLocalLanguage)
+{
+	if (m_localChatControl)
+	{
+		DEBUGLOG("Setting Speech-To-Text options.\n");
+
+		PartyVoiceChatTranscriptionOptions Options = PartyVoiceChatTranscriptionOptions::None;
+
+		if (bTranscribeSelf)
+		{
+			Options |= PartyVoiceChatTranscriptionOptions::TranscribeSelf;
+		}
+
+		if (bTranscribeOtherChatControlsWithMatchingLanguages)
+		{
+			Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithMatchingLanguages;
+		}
+
+		if (bTranscribeOtherChatControlsWithNonMatchingLanguages)
+		{
+			Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithNonMatchingLanguages;
+		}
+
+		if (bDisableHypothesisPhrases)
+		{
+			Options |= PartyVoiceChatTranscriptionOptions::DisableHypothesisPhrases;
+		}
+
+		if (bTranslateToLocalLanguage)
+		{
+			Options |= PartyVoiceChatTranscriptionOptions::TranslateToLocalLanguage;
+		}
+
+		// Set the transcription options on our chat control.
+		PartyError err = m_localChatControl->SetTranscriptionOptions(
+			Options, // Transcription options
+			nullptr  // Async identifier
+		);
+
+		if (PARTY_FAILED(err))
+		{
+			DEBUGLOG("SetTranscriptionOptions failed: %s\n", GetErrorMessage(err));
+		}
+	}
 }

--- a/Samples/All/BumbleRumble/Common/NetworkManager.cpp
+++ b/Samples/All/BumbleRumble/Common/NetworkManager.cpp
@@ -80,7 +80,7 @@ NetworkManager::NetworkManager() :
     m_localUser(nullptr),
     m_localChatControl(nullptr),
     m_partyInitialized(false),
-	m_enableCognitiveServices(false),
+    m_enableCognitiveServices(false),
     m_languageCode("en-US"),
     m_languageName("English (United States)")
 {
@@ -126,8 +126,8 @@ void NetworkManager::CreateLocalUser()
 {
     if (m_localUser == nullptr)
     {
-		auto& partyManager = PartyManager::GetSingleton();
-		PartyError err;
+        auto& partyManager = PartyManager::GetSingleton();
+        PartyError err;
         PartyString entityId = Managers::Get<PlayFabManager>()->EntityId().c_str();
         PartyString entityToken = Managers::Get<PlayFabManager>()->EntityToken().c_str();
 
@@ -148,68 +148,68 @@ void NetworkManager::CreateLocalUser()
 
 void NetworkManager::CreateLocalChatControl()
 {
-	if (m_localChatControl == nullptr)
-	{
-		auto& partyManager = PartyManager::GetSingleton();
-		PartyError err;
-		PartyLocalDevice* localDevice = nullptr;
+    if (m_localChatControl == nullptr)
+    {
+        auto& partyManager = PartyManager::GetSingleton();
+        PartyError err;
+        PartyLocalDevice* localDevice = nullptr;
 
-		// Retrieve the local device
-		err = partyManager.GetLocalDevice(&localDevice);
+        // Retrieve the local device
+        err = partyManager.GetLocalDevice(&localDevice);
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("GetLocalDevice failed: %hs\n", GetErrorMessage(err));
-			return;
-		}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("GetLocalDevice failed: %hs\n", GetErrorMessage(err));
+            return;
+        }
 
-		// Create a chat control for the local user on the local device
-		err = localDevice->CreateChatControl(
-			m_localUser,                                // Local user object
-			m_languageCode.c_str(),                     // Language id
-			nullptr,                                    // Async identifier
-			&m_localChatControl                         // OUT local chat control
-		);
+        // Create a chat control for the local user on the local device
+        err = localDevice->CreateChatControl(
+            m_localUser,                                // Local user object
+            m_languageCode.c_str(),                     // Language id
+            nullptr,                                    // Async identifier
+            &m_localChatControl                         // OUT local chat control
+        );
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("CreateChatControl failed: %hs\n", GetErrorMessage(err));
-			return;
-		}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("CreateChatControl failed: %hs\n", GetErrorMessage(err));
+            return;
+        }
 
-		// Use automatic settings for the audio input device
-		err = m_localChatControl->SetAudioInput(
-			PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
-			nullptr,                                        // Device id
-			nullptr                                         // Async identifier
-		);
+        // Use automatic settings for the audio input device
+        err = m_localChatControl->SetAudioInput(
+            PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
+            nullptr,                                        // Device id
+            nullptr                                         // Async identifier
+        );
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("SetAudioInput failed: %hs\n", GetErrorMessage(err));
-			return;
-		}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("SetAudioInput failed: %hs\n", GetErrorMessage(err));
+            return;
+        }
 
-		// Use automatic settings for the audio output device
-		err = m_localChatControl->SetAudioOutput(
-			PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
-			nullptr,                                        // Device id
-			nullptr                                         // Async identifier
-		);
+        // Use automatic settings for the audio output device
+        err = m_localChatControl->SetAudioOutput(
+            PartyAudioDeviceSelectionType::SystemDefault,   // Selection type
+            nullptr,                                        // Device id
+            nullptr                                         // Async identifier
+        );
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("SetAudioOutput failed: %hs\n", GetErrorMessage(err));
-		}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("SetAudioOutput failed: %hs\n", GetErrorMessage(err));
+        }
 
-		// Get the available list of text to speech profiles
-		err = m_localChatControl->PopulateAvailableTextToSpeechProfiles(nullptr);
+        // Get the available list of text to speech profiles
+        err = m_localChatControl->PopulateAvailableTextToSpeechProfiles(nullptr);
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("Populating available TextToSpeechProfiles failed: %s \n", GetErrorMessage(err));
-		}
-	}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("Populating available TextToSpeechProfiles failed: %s \n", GetErrorMessage(err));
+        }
+    }
 }
 
 void NetworkManager::Shutdown()
@@ -457,24 +457,24 @@ void NetworkManager::SendTextMessage(std::string text)
 
 void NetworkManager::SendTextAsVoice(std::string text)
 {
-	if (m_enableCognitiveServices)
-	{
-		if (m_localChatControl != nullptr)
-		{
-			DEBUGLOG("Requesting transcription of: %hs\n", text.c_str());
+    if (m_enableCognitiveServices)
+    {
+        if (m_localChatControl != nullptr)
+        {
+            DEBUGLOG("Requesting transcription of: %hs\n", text.c_str());
 
-			PartyError err = m_localChatControl->SynthesizeTextToSpeech(
-				PartySynthesizeTextToSpeechType::VoiceChat,
-				text.c_str(),                           // Text to synthesize
-				nullptr                                 // Async identifier
-			);
+            PartyError err = m_localChatControl->SynthesizeTextToSpeech(
+                PartySynthesizeTextToSpeechType::VoiceChat,
+                text.c_str(),                           // Text to synthesize
+                nullptr                                 // Async identifier
+            );
 
-			if (PARTY_FAILED(err))
-			{
-				DEBUGLOG("Failed to SynthesizeTextToSpeech: %hs\n", GetErrorMessage(err));
-			}
-		}
-	}
+            if (PARTY_FAILED(err))
+            {
+                DEBUGLOG("Failed to SynthesizeTextToSpeech: %hs\n", GetErrorMessage(err));
+            }
+        }
+    }
 }
 
 void NetworkManager::LeaveNetwork(std::function<void(void)> callback)
@@ -1200,7 +1200,7 @@ PartyChatControl* NetworkManager::GetChatControl(std::string& peer)
     return nullptr;
 }
 
-void BumbleRumble::NetworkManager::SetCognitiveServicesEnabled(bool bEnabled)
+void NetworkManager::SetCognitiveServicesEnabled(bool bEnabled)
 {
 	m_enableCognitiveServices = bEnabled;
 
@@ -1209,64 +1209,64 @@ void BumbleRumble::NetworkManager::SetCognitiveServicesEnabled(bool bEnabled)
 	SetVoiceChatTranscriptionOptions(bEnabled, bEnabled, bEnabled, false, bEnabled); 
 }
 
-void BumbleRumble::NetworkManager::SetTextChatTranslationOptions(bool bTranslateToLocalLanguage)
+void NetworkManager::SetTextChatTranslationOptions(bool bTranslateToLocalLanguage)
 {
-	DEBUGLOG("SetTextChatTranslationOptions: bTranslateToLocalLanguage = %s", bTranslateToLocalLanguage ? "Enabled" : "Disabled");
+    DEBUGLOG("SetTextChatTranslationOptions: bTranslateToLocalLanguage = %s", bTranslateToLocalLanguage ? "Enabled" : "Disabled");
 
-	// Enable translation to local language in chat controls.
-	PartyError err = m_localChatControl->SetTextChatOptions(
-		bTranslateToLocalLanguage ? PartyTextChatOptions::TranslateToLocalLanguage : PartyTextChatOptions::None,
-		nullptr
-	);
+    // Enable translation to local language in chat controls.
+    PartyError err = m_localChatControl->SetTextChatOptions(
+        bTranslateToLocalLanguage ? PartyTextChatOptions::TranslateToLocalLanguage : PartyTextChatOptions::None,
+        nullptr
+    );
 
-	if (PARTY_FAILED(err))
-	{
-		DEBUGLOG("SetTextChatOptions failed: %s\n", GetErrorMessage(err));
-	}
+    if (PARTY_FAILED(err))
+    {
+        DEBUGLOG("SetTextChatOptions failed: %s\n", GetErrorMessage(err));
+    }
 }
 
-void BumbleRumble::NetworkManager::SetVoiceChatTranscriptionOptions(bool bTranscribeSelf, bool bTranscribeOtherChatControlsWithMatchingLanguages, bool bTranscribeOtherChatControlsWithNonMatchingLanguages, bool bDisableHypothesisPhrases, bool bTranslateToLocalLanguage)
+void NetworkManager::SetVoiceChatTranscriptionOptions(bool bTranscribeSelf, bool bTranscribeOtherChatControlsWithMatchingLanguages, bool bTranscribeOtherChatControlsWithNonMatchingLanguages, bool bDisableHypothesisPhrases, bool bTranslateToLocalLanguage)
 {
-	if (m_localChatControl)
-	{
-		DEBUGLOG("Setting Speech-To-Text options.\n");
+    if (m_localChatControl)
+    {
+        DEBUGLOG("Setting Speech-To-Text options.\n");
 
-		PartyVoiceChatTranscriptionOptions Options = PartyVoiceChatTranscriptionOptions::None;
+        PartyVoiceChatTranscriptionOptions Options = PartyVoiceChatTranscriptionOptions::None;
 
-		if (bTranscribeSelf)
-		{
-			Options |= PartyVoiceChatTranscriptionOptions::TranscribeSelf;
-		}
+        if (bTranscribeSelf)
+        {
+            Options |= PartyVoiceChatTranscriptionOptions::TranscribeSelf;
+        }
 
-		if (bTranscribeOtherChatControlsWithMatchingLanguages)
-		{
-			Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithMatchingLanguages;
-		}
+        if (bTranscribeOtherChatControlsWithMatchingLanguages)
+        {
+            Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithMatchingLanguages;
+        }
 
-		if (bTranscribeOtherChatControlsWithNonMatchingLanguages)
-		{
-			Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithNonMatchingLanguages;
-		}
+        if (bTranscribeOtherChatControlsWithNonMatchingLanguages)
+        {
+            Options |= PartyVoiceChatTranscriptionOptions::TranscribeOtherChatControlsWithNonMatchingLanguages;
+        }
 
-		if (bDisableHypothesisPhrases)
-		{
-			Options |= PartyVoiceChatTranscriptionOptions::DisableHypothesisPhrases;
-		}
+        if (bDisableHypothesisPhrases)
+        {
+            Options |= PartyVoiceChatTranscriptionOptions::DisableHypothesisPhrases;
+        }
 
-		if (bTranslateToLocalLanguage)
-		{
-			Options |= PartyVoiceChatTranscriptionOptions::TranslateToLocalLanguage;
-		}
+        if (bTranslateToLocalLanguage)
+        {
+            Options |= PartyVoiceChatTranscriptionOptions::TranslateToLocalLanguage;
+        }
 
-		// Set the transcription options on our chat control.
-		PartyError err = m_localChatControl->SetTranscriptionOptions(
-			Options, // Transcription options
-			nullptr  // Async identifier
-		);
+        // Set the transcription options on our chat control.
+        PartyError err = m_localChatControl->SetTranscriptionOptions(
+            Options, // Transcription options
+            nullptr  // Async identifier
+        );
 
-		if (PARTY_FAILED(err))
-		{
-			DEBUGLOG("SetTranscriptionOptions failed: %s\n", GetErrorMessage(err));
-		}
-	}
+        if (PARTY_FAILED(err))
+        {
+            DEBUGLOG("SetTranscriptionOptions failed: %s\n", GetErrorMessage(err));
+        }
+    }
 }

--- a/Samples/All/BumbleRumble/Common/NetworkManager.h
+++ b/Samples/All/BumbleRumble/Common/NetworkManager.h
@@ -51,13 +51,19 @@ public:
     inline NetworkManagerState State() { return m_state; }
     inline bool IsConnected() const { return m_state == NetworkManagerState::NetworkConnected; }
 
+	inline bool IsCognitiveServicesEnabled() { return m_enableCognitiveServices; }
+	void SetCognitiveServicesEnabled(bool bEnabled);
+
 private:
     bool InternalConnectToNetwork(const char* networkId, Party::PartyNetworkDescriptor& descriptor);
     void CreateLocalUser();
+	void CreateLocalChatControl();
     std::string DisplayNameFromChatControl(Party::PartyChatControl* control);
     void UpdateTTSProfile();
+	void SetTextChatTranslationOptions(bool bTranslateToLocalLanguage);
+	void SetVoiceChatTranscriptionOptions(bool bTranscribeSelf, bool bTranscribeOtherChatControlsWithMatchingLanguages, bool bTranscribeOtherChatControlsWithNonMatchingLanguages, bool bDisableHypothesisPhrases, bool bTranslateToLocalLanguage);
 
-    std::function<void(std::string)> m_onNetworkCreated;
+	std::function<void(std::string)> m_onNetworkCreated;
     std::function<void(void)> m_onNetworkConnected;
     std::function<void(void)> m_onNetworkDestroyed;
     NetworkManagerState m_state;
@@ -67,6 +73,7 @@ private:
     Party::PartyLocalUser* m_localUser;
     Party::PartyLocalChatControl* m_localChatControl;
     bool m_partyInitialized;
+	bool m_enableCognitiveServices;
     std::string m_languageCode;
     std::string m_languageName;
     std::string m_localEntityId;

--- a/Samples/All/BumbleRumble/Common/OptionsPopUpScreen.cpp
+++ b/Samples/All/BumbleRumble/Common/OptionsPopUpScreen.cpp
@@ -100,21 +100,21 @@ OptionsPopUpScreen::OptionsPopUpScreen() : MenuScreen()
         },
         value));
 
-	if (Managers::Get<NetworkManager>()->State() == NetworkManagerState::NetworkConnected)
-	{
-		value = Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled() ? "Enabled" : "Disabled";
-		m_menuEntries.push_back(MenuEntry("Cognitive Services:", nullptr,
-			[this](bool adjustLeft)
-			{
-				adjustLeft;
-				bool bNewValue = !Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled();
+    if (Managers::Get<NetworkManager>()->State() == NetworkManagerState::NetworkConnected)
+    {
+        value = Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled() ? "Enabled" : "Disabled";
+        m_menuEntries.push_back(MenuEntry("Cognitive Services:", nullptr,
+            [this](bool adjustLeft)
+            {
+                adjustLeft;
+                bool bNewValue = !Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled();
 
-				m_menuEntries[MenuIndex::COGNITIVE_SERVICES].m_value = bNewValue ? "Enabled" : "Disabled";
+                m_menuEntries[MenuIndex::COGNITIVE_SERVICES].m_value = bNewValue ? "Enabled" : "Disabled";
 
-				Managers::Get<NetworkManager>()->SetCognitiveServicesEnabled(bNewValue);
-			},
-			value));
-	}
+                Managers::Get<NetworkManager>()->SetCognitiveServicesEnabled(bNewValue);
+            },
+            value));
+    }
 
     m_menuTextScale = 0.35f;
     SetTransitionDirections(false, false);

--- a/Samples/All/BumbleRumble/Common/OptionsPopUpScreen.cpp
+++ b/Samples/All/BumbleRumble/Common/OptionsPopUpScreen.cpp
@@ -45,7 +45,8 @@ static const char* s_languageNames[s_numberOfLanguages] =
 
 enum MenuIndex
 {
-    LANGUAGE_CODE
+    LANGUAGE_CODE,
+	COGNITIVE_SERVICES
 };
 
 OptionsPopUpScreen::OptionsPopUpScreen() : MenuScreen()
@@ -98,6 +99,22 @@ OptionsPopUpScreen::OptionsPopUpScreen() : MenuScreen()
                 );
         },
         value));
+
+	if (Managers::Get<NetworkManager>()->State() == NetworkManagerState::NetworkConnected)
+	{
+		value = Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled() ? "Enabled" : "Disabled";
+		m_menuEntries.push_back(MenuEntry("Cognitive Services:", nullptr,
+			[this](bool adjustLeft)
+			{
+				adjustLeft;
+				bool bNewValue = !Managers::Get<NetworkManager>()->IsCognitiveServicesEnabled();
+
+				m_menuEntries[MenuIndex::COGNITIVE_SERVICES].m_value = bNewValue ? "Enabled" : "Disabled";
+
+				Managers::Get<NetworkManager>()->SetCognitiveServicesEnabled(bNewValue);
+			},
+			value));
+	}
 
     m_menuTextScale = 0.35f;
     SetTransitionDirections(false, false);


### PR DESCRIPTION
Fixes # .

Changes proposed in this Pull Request:

Updated Bumble Rumble to have cognitive services defaulted to off.
Added new menu option to toggle cognitive services once you are in game.
Changed flow to only initialize the local chat control once you are connected to a network.