### PR TITLE
Unity Leaderboard sample fixes

### DIFF
--- a/Samples/Unity/PlayFabLeaderboardsUnity/Assets/Scripts/SampleManager.cs
+++ b/Samples/Unity/PlayFabLeaderboardsUnity/Assets/Scripts/SampleManager.cs
@@ -70,8 +70,6 @@ public class SampleManager : MonoBehaviour
 		}
 
 		RefreshLeaderboards();
-
-		ShowLeaderboard(CurrentLeaderboard);
 	}
 
 	public void PrevLeaderboard()

--- a/Samples/Unity/PlayFabLeaderboardsUnity/readme.md
+++ b/Samples/Unity/PlayFabLeaderboardsUnity/readme.md
@@ -31,6 +31,11 @@ There are no known issues.
   * __Reset Frequency:__ Manually
   * __Aggregation Method:__ Sum
 * Copy the contents of 'cloudscript.js' to your cloud script
+* The following rule needs to be created to link the client calls to the cloud script
+  * __Name:__ update_statistic
+  * __Event type:__ Custom Event - update_statistic
+  * __Action:__ Execute Cloud Script
+  * __Cloud Script Function:__ updateStatistic
 
  ### Using the Sample
  


### PR DESCRIPTION
Fixes two issues:

1. The readme didn't mention the required rule that must be created to update the leaderboards.
2. There was a script error when switching leaderboards in the UI. This was due to the code not waiting on the GetLeaderboards request to complete before accessing the result. This access was extraneous, though, as the OnSuccess handler is already set up to refresh the UI.