### PR TITLE
Update CloudScript.js

### DIFF
--- a/Recipes/ProgressiveRewards/CloudScript.js
+++ b/Recipes/ProgressiveRewards/CloudScript.js
@@ -121,7 +121,7 @@ function UpdateTrackerData(data)
         "PlayFabId": currentPlayerId,
         "Data": {}
     };
-    UpdateUserReadOnlyDataRequest.Data[CHECK_IN_TRACKER] = JSON.stringify(data);
+    UpdateUserReadOnlyDataRequest.Data[CHECK_IN_TRACKER] = typeof data === "string" ? data : JSON.stringify(data);
 
     server.UpdateUserReadOnlyData(UpdateUserReadOnlyDataRequest);
 }


### PR DESCRIPTION
stringifying a string adds two double quotes " at the beginning/end of the string which proposes problems when parsing which happens when calling ResetTracker() then sending the json string to be stringified once more in UpdateTrackerData()

Fixes # .
Added a type check to see if it's a string leave as is else stringify it to json

Changes proposed in this Pull Request:
